### PR TITLE
Restrict CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: 
+      - main
 
 jobs:
   build:
@@ -28,6 +34,7 @@ jobs:
 
   deploy:
     name: Deploy
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment: Production
     steps:


### PR DESCRIPTION
Restrict CI workflow to PRs or pushes to `main`.  Restrict deploy job to `main`.